### PR TITLE
Get party's postcode from party's tax ID zone

### DIFF
--- a/cfdi.go
+++ b/cfdi.go
@@ -81,7 +81,7 @@ func NewDocument(env *gobl.Envelope) (*Document, error) {
 		Serie:             inv.Series,
 		Folio:             inv.Code,
 		Fecha:             formatIssueDate(inv.IssueDate),
-		LugarExpedicion:   inv.Supplier.Addresses[0].Code,
+		LugarExpedicion:   inv.Supplier.TaxID.Zone.String(),
 		SubTotal:          inv.Totals.Total.String(),
 		Total:             inv.Totals.TotalWithTax.String(),
 		Moneda:            string(inv.Currency),

--- a/parties.go
+++ b/parties.go
@@ -32,7 +32,7 @@ func newReceptor(customer *org.Party) *Receptor {
 	receptor := &Receptor{
 		Rfc:                     customer.TaxID.Code.String(),
 		Nombre:                  customer.Name,
-		DomicilioFiscalReceptor: customer.Addresses[0].Code,
+		DomicilioFiscalReceptor: customer.TaxID.Zone.String(),
 		RegimenFiscalReceptor:   RegimenFiscalGeneral,
 		UsoCFDI:                 UsoCFDIGastosGenerales,
 	}

--- a/test/data/bare-minimum-invoice.json
+++ b/test/data/bare-minimum-invoice.json
@@ -18,28 +18,18 @@
     "supplier": {
       "tax_id": {
         "country": "MX",
-        "code": "EKU9003173C9"
+        "code": "EKU9003173C9",
+        "zone": "26015"
       },
-      "name": "ESCUELA KEMPER URGATE",
-      "addresses": [
-        {
-          "locality": "Piedras Negras",
-          "code": "26015"
-        }
-      ]
+      "name": "ESCUELA KEMPER URGATE"
     },
     "customer": {
       "tax_id": {
         "country": "MX",
-        "code": "URE180429TM6"
+        "code": "URE180429TM6",
+        "zone": "65000"
       },
-      "name": "UNIVERSIDAD ROBOTICA ESPAÑOLA",
-      "addresses": [
-        {
-          "locality": "Anáhuac",
-          "code": "65000"
-        }
-      ]
+      "name": "UNIVERSIDAD ROBOTICA ESPAÑOLA"
     },
     "lines": [
       {


### PR DESCRIPTION
* Since each party's post code is fiscally relevant (for instance, to allow the application of the border reduced VAT), the Tax ID Zone seems appropriate to carry it.