### PR TITLE
Map `FormaPago` and `UsoCFDI` fields using MX regime

### DIFF
--- a/cfdi_test.go
+++ b/cfdi_test.go
@@ -31,7 +31,7 @@ func TestComprobante(t *testing.T) {
 		assert.Equal(t, "MXN", doc.Moneda)
 		assert.Equal(t, "01", doc.Exportacion)
 		assert.Equal(t, "PUE", doc.MetodoPago)
-		assert.Equal(t, "99", doc.FormaPago)
+		assert.Equal(t, "03", doc.FormaPago)
 	})
 }
 

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/invopop/gobl.cfdi
 go 1.20
 
 require (
-	github.com/invopop/gobl v0.50.3
+	github.com/invopop/gobl v0.51.1
 	github.com/magefile/mage v1.15.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -789,6 +789,8 @@ github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:
 github.com/ianlancetaylor/demangle v0.0.0-20200824232613-28f6c0f3b639/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/invopop/gobl v0.50.3 h1:wANiqA/to9X415MUXkJh7LGbPp6d04czkOFM2n0UoR4=
 github.com/invopop/gobl v0.50.3/go.mod h1:X7EqVSEfeeIymdaOUrwkHu+OPPNATAHDQ8FPs2BvZFM=
+github.com/invopop/gobl v0.51.1 h1:70ayZ4rAtvHP6NJmH372pB94GNFsCjkStYnf69DE35s=
+github.com/invopop/gobl v0.51.1/go.mod h1:X7EqVSEfeeIymdaOUrwkHu+OPPNATAHDQ8FPs2BvZFM=
 github.com/invopop/jsonschema v0.7.0 h1:2vgQcBz1n256N+FpX3Jq7Y17AjYt46Ig3zIWyy770So=
 github.com/invopop/jsonschema v0.7.0/go.mod h1:O9uiLokuu0+MGFlyiaqtWxwqJm41/+8Nj0lD7A36YH0=
 github.com/invopop/validation v0.3.0 h1:o260kbjXzoBO/ypXDSSrCLL7SxEFUXBsX09YTE9AxZw=

--- a/parties.go
+++ b/parties.go
@@ -28,13 +28,13 @@ func newEmisor(supplier *org.Party) *Emisor {
 	return emisor
 }
 
-func newReceptor(customer *org.Party) *Receptor {
+func newReceptor(customer *org.Party, usoCFDI string) *Receptor {
 	receptor := &Receptor{
 		Rfc:                     customer.TaxID.Code.String(),
 		Nombre:                  customer.Name,
 		DomicilioFiscalReceptor: customer.TaxID.Zone.String(),
 		RegimenFiscalReceptor:   RegimenFiscalGeneral,
-		UsoCFDI:                 UsoCFDIGastosGenerales,
+		UsoCFDI:                 usoCFDI,
 	}
 
 	return receptor

--- a/parties_test.go
+++ b/parties_test.go
@@ -32,6 +32,6 @@ func TestReceptor(t *testing.T) {
 		assert.Equal(t, "UNIVERSIDAD ROBOTICA ESPAÑOLA", r.Nombre)
 		assert.Equal(t, "65000", r.DomicilioFiscalReceptor)
 		assert.Equal(t, "601", r.RegimenFiscalReceptor)
-		assert.Equal(t, "G03", r.UsoCFDI)
+		assert.Equal(t, "G01", r.UsoCFDI)
 	})
 }

--- a/test/data/bare-minimum-invoice.json
+++ b/test/data/bare-minimum-invoice.json
@@ -4,7 +4,7 @@
     "uuid": "c4ed7c55-fef6-11ed-98ea-e6a7901137ed",
     "dig": {
       "alg": "sha256",
-      "val": "b28de1631ce7646c8852e5197db6d288af321169e1fde46cdd19dc6551da17af"
+      "val": "e425e2e49d3f11df3f74719ad8188a4b0d904ecc481811b892d787dc94b55e3e"
     },
     "draft": true
   },
@@ -14,6 +14,11 @@
     "code": "0010",
     "type": "standard",
     "currency": "MXN",
+    "tax": {
+      "tags": [
+        "use+goods-acquisition"
+      ]
+    },
     "issue_date": "2023-05-29",
     "supplier": {
       "tax_id": {
@@ -50,6 +55,11 @@
         "total": "200.00"
       }
     ],
+    "payment": {
+      "instructions": {
+        "key": "credit-transfer"
+      }
+    },
     "totals": {
       "sum": "200.00",
       "total": "200.00",


### PR DESCRIPTION
* Uses the mapping codes added in https://github.com/invopop/gobl/pull/158 to map the value of the `FormaPago` and `UsoCFDI` fields.
* Supersedes #6 