### PR TITLE
Fix all exempt case & improve unsupported validations

### DIFF
--- a/cfdi.go
+++ b/cfdi.go
@@ -174,6 +174,10 @@ func validateSupport(inv *bill.Invoice) error {
 		if inv.Tax.ContainsTag(tax.TagSelfBilled) {
 			return fmt.Errorf("self-billed is not supported")
 		}
+
+		if inv.Tax.ContainsTag(tax.TagCustomerRates) {
+			return fmt.Errorf("customer rates are not supported")
+		}
 	}
 
 	if inv.Currency != currency.MXN {

--- a/cfdi.go
+++ b/cfdi.go
@@ -3,6 +3,7 @@ package cfdi
 
 import (
 	"encoding/xml"
+	"errors"
 	"fmt"
 
 	"cloud.google.com/go/civil"
@@ -19,6 +20,7 @@ import (
 	"github.com/invopop/gobl/regimes/mx"
 	"github.com/invopop/gobl/schema"
 	"github.com/invopop/gobl/tax"
+	"github.com/invopop/validation"
 )
 
 // CFDI schema constants
@@ -62,6 +64,9 @@ const (
 	ObjetoImpNo = "01" // not subject to tax
 	ObjetoImpSi = "02" // subject to tax
 )
+
+// ErrNotSupported is returned when the conversion of the invoice is not supported
+var ErrNotSupported = errors.New("not supported")
 
 // Document is a pseudo-model for containing the XML document being created
 type Document struct {
@@ -156,38 +161,44 @@ func NewDocument(env *gobl.Envelope) (*Document, error) {
 }
 
 func validateSupport(inv *bill.Invoice) error {
+	errs := validation.Errors{}
+
 	if len(inv.Charges) > 0 {
-		return fmt.Errorf("charges are not supported")
+		errs["charges"] = ErrNotSupported
 	}
 
 	for _, l := range inv.Lines {
 		if len(l.Charges) > 0 {
-			return fmt.Errorf("line charges are not supported")
+			errs["line charges"] = ErrNotSupported
 		}
 	}
 
 	if len(inv.Outlays) > 0 {
-		return fmt.Errorf("outlays are not supported")
+		errs["outlays"] = ErrNotSupported
 	}
 
 	if inv.Tax != nil {
 		if inv.Tax.ContainsTag(tax.TagSelfBilled) {
-			return fmt.Errorf("self-billed is not supported")
+			errs["self-billed"] = ErrNotSupported
 		}
 
 		if inv.Tax.ContainsTag(tax.TagCustomerRates) {
-			return fmt.Errorf("customer rates are not supported")
+			errs["customer-rates"] = ErrNotSupported
 		}
 	}
 
 	if inv.Currency != currency.MXN {
-		return fmt.Errorf("currencies other than MXN are not supported")
+		errs["currency"] = ErrNotSupported
 	}
 
 	for _, l := range inv.Lines {
 		if l.Item.Currency != currency.CodeEmpty && l.Item.Currency != currency.MXN {
-			return fmt.Errorf("line currencies other than MXN are not supported")
+			errs["line currency"] = ErrNotSupported
 		}
+	}
+
+	if len(errs) > 0 {
+		return errs
 	}
 
 	return nil

--- a/taxes.go
+++ b/taxes.go
@@ -69,7 +69,15 @@ func newImpuestos(totals *bill.Totals, currency *currency.Code, regime *tax.Regi
 	empty := true
 	if len(traslados) > 0 {
 		impuestos.Traslados = &Traslados{traslados}
-		impuestos.TotalImpuestosTrasladados = totalTraslados.String()
+
+		// Set tax total only if there are non-exempt taxes
+		for _, t := range traslados {
+			if t.TipoFactor != TipoFactorExento {
+				impuestos.TotalImpuestosTrasladados = totalTraslados.String()
+				break
+			}
+		}
+
 		empty = false
 	}
 	if len(retenciones) > 0 {

--- a/taxes_test.go
+++ b/taxes_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/invopop/gobl.cfdi/test"
+	"github.com/invopop/gobl/tax"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -22,6 +23,18 @@ func TestImpuestos(t *testing.T) {
 		assert.Equal(t, "002", tr.Impuesto)
 		assert.Equal(t, "Tasa", tr.TipoFactor)
 		assert.Equal(t, "0.160000", tr.TasaOCuota)
+	})
+
+	t.Run("should return a Document with the Impuestos data when all taxes are exempt", func(t *testing.T) {
+		inv, err := test.LoadTestInvoice("invoice-b2b-bare.json")
+		require.NoError(t, err)
+
+		inv.Lines[0].Taxes[0].Rate = tax.RateExempt
+
+		doc, err := test.GenerateCFDIFrom(inv)
+		require.NoError(t, err)
+
+		assert.Equal(t, "", doc.Impuestos.TotalImpuestosTrasladados)
 	})
 
 	t.Run("should return a Document with the Impuestos data of each Concepto", func(t *testing.T) {


### PR DESCRIPTION
* Generates the expected CFDI when the GOBL invoice only includes exempt taxes
* Brings back the customer-rate unsupported validation
* Returns unsupported errors as validation errors so that the module handles them with a KO response