### PR TITLE
Fixing bug on cmd

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,13 +69,13 @@ For details on support for converting Addendas, please see the [addendas package
 The GOBL to CFDI tool also includes a command line helper. You can find pre-built [gobl.cfdi binaries](https://github.com/invopop/gobl.cfdi/releases) in the github repository, or install manually in your Go environment with:
 
 ```bash
-go install github.com/invopop/gobl.cfdi
+go install ./cmd/gobl.cfdi
 ```
 
 Usage is very straightforward:
 
 ```bash
-gobl.cfdi convert ./test/data/invoice.json
+gobl.cfdi convert ./test/data/invoice-b2b-bare.json
 ```
 
 Which should produce something like:

--- a/cmd/gobl.cfdi/convert.go
+++ b/cmd/gobl.cfdi/convert.go
@@ -20,7 +20,7 @@ func convert(o *rootOpts) *convertOpts {
 
 func (c *convertOpts) cmd() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "convert [infile] [outfile]",
+		Use:   "convert <infile> [outfile]",
 		Short: "Convert a GOBL JSON into a CFDI XML document for Mexico",
 		RunE:  c.runE,
 	}
@@ -30,6 +30,10 @@ func (c *convertOpts) cmd() *cobra.Command {
 
 func (c *convertOpts) runE(cmd *cobra.Command, args []string) error {
 	// ctx := commandContext(cmd)
+
+	if len(args) == 0 || len(args) > 2 {
+		return fmt.Errorf("expected one or two arguments, the command usage is `gobl.cfdi convert <infile> [outfile]`")
+	}
 
 	input, err := openInput(cmd, args)
 	if err != nil {


### PR DESCRIPTION
While doing the gobl.tin cmd functionality, I was taking this as reference and I came up with 1 bug and I also updated the README:

- If you use the command convert without arguments, the cmd crashes. To fix this I added a condition that when the number of arguments is not 1 or 2 an error displays.
- In the README. documentation for cms used the the file ./test/data/invoice.json which no longer exists. I changed it for ./test/data/invoice-b2b-bare.json to match the response from below. I also changed the command for installing gobl.cfdi because the one before wasn't working: I proposed go install ./cmd/gobl.cfdi, which worked for me. 