### PR TITLE
Support customer post code from address

### DIFF
--- a/parties.go
+++ b/parties.go
@@ -58,11 +58,16 @@ func newReceptor(customer *org.Party, issuePlace string) *Receptor {
 		}
 	}
 
+	postcode := customer.Ext[cfdi.ExtKeyPostCode].String() // TODO: Drop support for ExtKeyPostCode
+	if postcode == "" && len(customer.Addresses) > 0 {
+		postcode = customer.Addresses[0].Code
+	}
+
 	return &Receptor{
 		Nombre:                  customer.Name,
 		Rfc:                     customer.TaxID.Code.String(),
 		RegimenFiscalReceptor:   customer.Ext[cfdi.ExtKeyFiscalRegime].String(),
 		UsoCFDI:                 customer.Ext[cfdi.ExtKeyUse].String(),
-		DomicilioFiscalReceptor: customer.Ext[cfdi.ExtKeyPostCode].String(),
+		DomicilioFiscalReceptor: postcode,
 	}
 }

--- a/parties_test.go
+++ b/parties_test.go
@@ -4,6 +4,8 @@ import (
 	"testing"
 
 	"github.com/invopop/gobl.cfdi/test"
+	"github.com/invopop/gobl/addons/mx/cfdi"
+	"github.com/invopop/gobl/org"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -61,5 +63,24 @@ func TestReceptor(t *testing.T) {
 		assert.Equal(t, "S01", r.UsoCFDI)
 		assert.Equal(t, "9014514805", r.NumRegIdTrib)
 		assert.Equal(t, "COL", r.ResidenciaFiscal)
+	})
+
+	t.Run("should map DomicilioFiscal from customer post code", func(t *testing.T) {
+		inv, err := test.LoadTestInvoice("invoice-b2b-bare.json")
+		require.NoError(t, err)
+
+		delete(inv.Customer.Ext, cfdi.ExtKeyPostCode)
+		inv.Customer.Addresses = []*org.Address{{Code: "21000"}}
+
+		doc, err := test.GenerateCFDIFrom(inv)
+		require.NoError(t, err)
+
+		r := doc.Receptor
+
+		assert.Equal(t, "URE180429TM6", r.Rfc)
+		assert.Equal(t, "UNIVERSIDAD ROBOTICA ESPAÑOLA", r.Nombre)
+		assert.Equal(t, "21000", r.DomicilioFiscalReceptor)
+		assert.Equal(t, "601", r.RegimenFiscalReceptor)
+		assert.Equal(t, "G01", r.UsoCFDI)
 	})
 }


### PR DESCRIPTION
* Sets the `DomicilioFiscalReceptor` from either the `mx-cfdi-post-code` extensions or the customer first address post code
* Works both before and after https://github.com/invopop/gobl/pull/403, allowing for a smooth transition